### PR TITLE
make sure connection is open before sending command

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,9 +24,11 @@ function connect() {
   ws = new WebSocket(serverUrl, { headers });
 
   ws.on('open', () => {
-    log('Succesful connection established');
-    retries = 0;
-    ws.sendCommand('REGISTER_NETWORK', networkId);
+    if (this._wsConn.readyState === this._wsConn.OPEN) {
+      log('Succesful connection established');
+      retries = 0;
+      ws.sendCommand('REGISTER_NETWORK', networkId);
+    }
   });
 
   ws.on('close', (code, message) => log('Connection closed.', code, message));


### PR DESCRIPTION
__Supposedly__ fixes #8. I am still skeptical and wasn't able to reproduce it, but the stack trace is pretty clear and seems to point out that the connection wasn't open inside the `onOpen` callback.